### PR TITLE
chore(release): prepare v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on Keep a Changelog:
+https://keepachangelog.com/en/1.1.0/
+
+## [0.2.0] - 2026-01-30
+
+### Added
+- Mobile editor layout (<=768px) with bottom tray navigation: Presets / Crop / Healing / Edit / History (PR #20).
+- Edit sub-tabs on mobile: Basic / Color / Tone / Details / Geometry.
+- "Smart nudge" camera behavior to keep the image visible as the mobile tray opens/resizes.
+- `useIsMobile` hook to switch between desktop and mobile layouts.
+- Unit tests for mobile tray nudge behavior.
+
+### Changed
+- Refactored the desktop resizable layout into a standalone layout component.
+- Presets UI moved into its own accordion in the desktop layout.
+- Mobile tray overlays the canvas (tray scrolls internally; the page doesn't).
+- Mobile CSS improvements for safe-area padding and touch ergonomics.
+
+### Fixed
+- Camera clamping on viewport resize.
+- Multiple mobile tray sizing/scroll/click issues across panels and tool rows.
+
+## [0.1.2] - 2026-01-22
+
+### Added
+- Initial npm release of `@mukeshsoni/react-image-editor`.
+- Library build + publish setup (Vite library build, TypeScript declarations, and `prepack` pipeline).
+- MIT license.
+- GitHub Pages demo deployment workflow.
+
+### Changed
+- Updated package metadata (repository/homepage/bugs) and improved README usage docs.
+
+[0.2.0]: https://github.com/mukeshsoni/react-image-editor/compare/v0.1.2...v0.2.0
+[0.1.2]: https://github.com/mukeshsoni/react-image-editor/releases/tag/v0.1.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mukeshsoni/react-image-editor",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mukeshsoni/react-image-editor",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mukeshsoni/react-image-editor",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "type": "module",
   "license": "MIT",
   "description": "A Lightroom-style, non-destructive image editor for React (canvas-based).",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "files": [
     "dist",
     "styles.css",
+    "CHANGELOG.md",
     "LICENSE",
     "README.md"
   ],


### PR DESCRIPTION
## What

Prepare the v0.2.0 npm release by adding a consumer-facing changelog and ensuring it’s included in the published package.

## Changes

Add CHANGELOG.md with release notes for:
0.2.0 (mobile layout support from PR #20)
0.1.2 (initial public/npm launch release)
Update package.json#files to include CHANGELOG.md so it ships in the npm tarball

## Verification

npx vitest run
npm run lint
npm run build:lib && npm run build:types
npm publish --dry-run (confirmed CHANGELOG.md is included)
